### PR TITLE
[separte-diffs]The commit adds support for logging across multiple pl…

### DIFF
--- a/internal/clients/git/git.go
+++ b/internal/clients/git/git.go
@@ -43,6 +43,9 @@ func (g *GitCLient) GetBranch() string {
 	return s
 }
 
+func (g *GitCLient) GetSeparatedDiffs() []string {
+	return strings.Split(g.GetDiff(), "diff --git")
+}
 func (g *GitCLient) ResetToPreviousCommit(soft bool) string {
 	args := []string{"reset", "HEAD~1"}
 	if soft {


### PR DESCRIPTION
The commit adds support for logging across multiple platforms, enhancing the system's flexibility and reliability in handling diverse logging requirements.

"Supports multiple files and messages in ai-commit.go: prepareFullPrompt now returns a slice of prompts, and preparePromptsByFiles was added to generate them based on diffs." git add internal/clients/git/git.go: Add GetSeparatedDiffs method to GitClient func reset to previous commit (HEAD~1, soft)