### PR TITLE
[auto-reject-long-messages]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,6 @@ build:
 	mkdir "bin"
 	go build -o bin/${BINARY_NAME} cmd/ai-commit/main.go
 
-
+rebuild:
+	make clean
+	make build

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ make install
 ```
 Will try to compile project locally into ./bin directory
 
+bad usecases: 
+one single change in a long line
+
+Pro-tips:
+-
+- Even tho deepseek-r1 is supported with local model it's not the best model for speed, use it on more trickier commits and be ready to clean up th final message
+- 
 
 upcoming changes:
 -
@@ -75,10 +82,11 @@ upcoming changes:
 - 10 - separate config file
 - 11 - support pattern for skipping files
 - 12 - interactive mode (semi done, needs improvements)
-- 13 - automatically reject messages longer than certain number of characters 
+- ~~13 - automatically reject messages longer than certain number of characters~~
 - 14 - support auto git diff context for smaller changes to give llm more lines to process
 - 15 - improve visibility on progress for creating commit message
 - 16 - custom prefix or use prefix from previous message
 - 17 - generate md doc for the diff
 - 18 - mixed prompt generation (choosing if you want to split files into several contexts)
 - 19 - support special diff splitters for better context
+- 20 - plugin support

--- a/cmd/ai-commit/main.go
+++ b/cmd/ai-commit/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	builder := config_reader.NewConfigBuilder()
-	builder.SetModelFromFlag().SetCleanThinkBlock().SetSeparateFilesFromFlag().SetLoopFromFlag().SetApiEndpointFromFlag().SetInteractive()
+	builder.SetModelFromFlag().SetCleanThinkBlock().SetSeparateFilesFromFlag().SetLoopFromFlag().SetApiEndpointFromFlag().SetInteractive().SetAutoRejectLongMessages()
 	cfg := builder.BuildConfig()
 	a := app.NewApp(cfg)
 	log.Println("ai-commit started")

--- a/internal/clients/config-reader/config-reader.go
+++ b/internal/clients/config-reader/config-reader.go
@@ -8,24 +8,26 @@ import (
 )
 
 type Config struct {
-	Prompt          string
-	Model           string
-	CLeanThinkBlock bool
-	SeparateDiff    bool
-	LoopPrompt      string
-	Loop            bool
-	LLMEndpoint     string
-	Interactive     bool
+	Prompt                    string
+	Model                     string
+	CLeanThinkBlock           bool
+	SeparateDiff              bool
+	LoopPrompt                string
+	Loop                      bool
+	LLMEndpoint               string
+	Interactive               bool
+	RegenerateForLengthPrompt string
+	AutoRejectLongMessages    int
 }
 
 type configBuilder struct {
-	model           *string
-	cleanThinkBlock *bool
-	separateDiff    *bool
-	loop            *bool
-	interactive     *bool
-
-	llmEndpoint *string
+	model                  *string
+	cleanThinkBlock        *bool
+	separateDiff           *bool
+	loop                   *bool
+	interactive            *bool
+	autoRejectLongMessages *int
+	llmEndpoint            *string
 }
 
 func NewConfigBuilder() *configBuilder {
@@ -62,6 +64,11 @@ func (builder *configBuilder) SetInteractive() *configBuilder {
 	return builder
 }
 
+func (builder *configBuilder) SetAutoRejectLongMessages() *configBuilder {
+	builder.autoRejectLongMessages = flag.Int("auto-reject-length", 150, "will reject messages long than certain length; <= 0 will allow any message length")
+	return builder
+}
+
 func (builder *configBuilder) BuildConfig() *Config {
 	flag.Parse()
 	if *builder.interactive {
@@ -70,17 +77,22 @@ func (builder *configBuilder) BuildConfig() *Config {
 	log.Printf("model: %v \n", *builder.model)
 	log.Printf("clean think block: %v, \n", *builder.cleanThinkBlock)
 	log.Printf("separate diff: %v \n", *builder.separateDiff)
+	if *builder.autoRejectLongMessages > 0 {
+		log.Printf("rejecting message longer than: %v symbols \n", *builder.autoRejectLongMessages)
+	}
 	if *builder.loop {
 		log.Printf("loop: %v \n", *builder.loop)
 	}
 	return &Config{
-		Model:           *builder.model,
-		CLeanThinkBlock: *builder.cleanThinkBlock,
-		SeparateDiff:    *builder.separateDiff,
-		Loop:            *builder.loop,
-		Prompt:          constants.Prompt,
-		LoopPrompt:      constants.LoopPrompt,
-		LLMEndpoint:     *builder.llmEndpoint,
-		Interactive:     *builder.interactive,
+		Model:                     *builder.model,
+		CLeanThinkBlock:           *builder.cleanThinkBlock,
+		SeparateDiff:              *builder.separateDiff,
+		Loop:                      *builder.loop,
+		Prompt:                    constants.Prompt,
+		LoopPrompt:                constants.LoopPrompt,
+		RegenerateForLengthPrompt: constants.RegenerateForLengthPrompt,
+		LLMEndpoint:               *builder.llmEndpoint,
+		AutoRejectLongMessages:    *builder.autoRejectLongMessages,
+		Interactive:               *builder.interactive,
 	}
 }

--- a/internal/const.go
+++ b/internal/const.go
@@ -1,4 +1,8 @@
 package internal
 
-const Prompt = "Write a professional short git commit message based on the a diff below in English language. Do not preface the commit with anything, use the present tense, return the full sentence, and use the conventional commits specification (<type in lowercase>: <subject>):\n"
+const Prompt2 = "Write a professional short git commit message based on the a diff below in English language. Do not preface the commit with anything, use the present tense, return the full sentence, and use the conventional commits specification (<type in lowercase>: <subject>):\n"
+const Prompt = "You are a senior software engineer.\nYou will be given a git diff.\nGenerate a single, concise one line commit message in imperative tense (e.g. “Fix bug”, “Add feature”) that accurately summarizes the changes. Do not preface the commit with anything, use the present tense, return the full sentence in one line, and use the conventional commits specification (<type in lowercase>: <subject>). Limit your output to at most 150 characters. **Output only the commit message nothing else**.\nDiff:\n"
 const LoopPrompt = "Shorten following text to a professional short git commit message in English language, do not preface the commit with anything, use the present tense, return the full sentence, and use the conventional commits specification (<type in lowercase>: <subject>):\n"
+const RegenerateForLengthPrompt = "You will be provided with a long commit message, you need to extract the core of the message so the sum of the wouldn't exceed: {length} symbols, do not add explanation in the final answer, only the commit message"
+
+var LengthPrompt = "The length of the git commit should be no longer than %v symbols"


### PR DESCRIPTION
feat: adds rebuild target to Makefile
feat: add pro-tips and upcoming changes to README
feat: add auto-reject long messages
feat: add length constraints and regenerate commit messages
feat: add auto-reject long messages and regenerate prompt
feat: add new prompt constants